### PR TITLE
Fixed sign waiver loop

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,9 +45,8 @@ firebase.auth().onAuthStateChanged((u) => {
 // Validate based on category
 function validateInput(category, id) {
   const regex = {
-    'Undergraduate': /^f00\d[0-9a-zA-Z]{3}$/,
-    'Faculty': /^d\d{4}[0-9a-zA-Z]{2}$/,
-    'Other': /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+    'netID': /^[fd][0-9a-zA-Z]{6}$/,
+    'email': /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
   };
   return regex[category].test(id);
 }
@@ -69,7 +68,7 @@ async function signWaiver(event) {
   const name = document.getElementById('name').value.trim();
 
   if (!validateInput(category, id)) {
-    alert('Invalid ID or Email format.');
+    alert('Invalid netID or Email format.');
     return;
   }
 

--- a/pages/waiver.html
+++ b/pages/waiver.html
@@ -33,17 +33,16 @@ In signing this acknowledgment & assumption of risk, hold harmless agreement, re
     <!-- Waiver form -->
     <form id="waiverform">
       <div class="form-group">
-        <label for="category">Category:</label>
-        <select class="form-control" id="category" required>
-          <option value="Undergraduate">Undergraduate</option>
-          <option value="Faculty">Faculty</option>
-          <option value="Other">Other</option>
-        </select>
+          <label for="category">Sign in with:</label>
+          <select class="form-control" id="category" required>
+            <option value="netID">netID</option>
+            <option value="email">Email</option>
+          </select>
       </div>
 
       <div class="form-group">
-        <label for="id">ID/Email:</label>
-        <input type="text" class="form-control" id="id" required>
+          <label for="id">netID or Dartmouth Email:</label>
+          <input type="text" class="form-control" id="id" required>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
# Fixed sign waiver loop

New climbers who aren't undergrad get a glitch where they have to sign the waiver over and over again. Grad students have been signing in as undergrads to get past this bug.

1. New climbers, from the sign in page (signin.html) click the link to sign the waiver, which takes them to the waiver page (waiver.html). From here they try to sign in as 'other' from the dropdowns using their netID, and the loop begins. Where NetID is a 7-digit combination of letters and numbers, such as "f12345x". The system reports signing the waiver successfully, but when they try to sign in, it reports to them that they still need to sign the waiver. This is the loop.

2. The bug seems to be happening only for undergrads so far

3. After the climber signs the waiver, what is supposed to happen is they go to sign in and it'll tell them that they have signed in successfully.

4. This is handled via a combination of firebase and js scripts (main.js). The scripts query firestore but it seems that the logic is handled in the scripts themselves.

closes #44 